### PR TITLE
feat: 属性入力をkey:value二分割フィールドに変更

### DIFF
--- a/.claude/skills/conceptual-model/conceptual-model-template.html
+++ b/.claude/skills/conceptual-model/conceptual-model-template.html
@@ -869,6 +869,12 @@ function renderEntity(node, path) {
     const keyStr = colonIdx >= 0 ? attr.substring(0, colonIdx).trim() : attr.trim();
     const valStr = colonIdx >= 0 ? attr.substring(colonIdx + 1).trim() : '';
 
+    const commitAttr = () => {
+      pushUndo();
+      node.attributes[i] = keyInput.value.trim() + ': ' + valInput.value.trim();
+      updateJsonPanel();
+    };
+
     const keyInput = document.createElement('input');
     keyInput.className = 'attr-key';
     keyInput.value = keyStr;
@@ -876,11 +882,7 @@ function renderEntity(node, path) {
     requestAnimationFrame(() => fitInputWidth(keyInput));
     keyInput.addEventListener('click', e => e.stopPropagation());
     keyInput.addEventListener('input', () => fitInputWidth(keyInput));
-    keyInput.addEventListener('change', () => {
-      pushUndo();
-      node.attributes[i] = keyInput.value.trim() + ': ' + valInput.value.trim();
-      updateJsonPanel();
-    });
+    keyInput.addEventListener('change', commitAttr);
     tag.appendChild(keyInput);
 
     const sep = document.createElement('span');
@@ -895,11 +897,7 @@ function renderEntity(node, path) {
     requestAnimationFrame(() => fitInputWidth(valInput));
     valInput.addEventListener('click', e => e.stopPropagation());
     valInput.addEventListener('input', () => fitInputWidth(valInput));
-    valInput.addEventListener('change', () => {
-      pushUndo();
-      node.attributes[i] = keyInput.value.trim() + ': ' + valInput.value.trim();
-      updateJsonPanel();
-    });
+    valInput.addEventListener('change', commitAttr);
     tag.appendChild(valInput);
 
     const remove = document.createElement('span');


### PR DESCRIPTION
## Summary
- 概念モデルHTMLエディタの属性入力を単一テキストフィールドから「フィールド名 : 説明」の二分割構造に変更
- key側は太字、value側はグレー文字で視覚的に区別
- 新規属性のデフォルトを `field: 説明` に変更し、フォーマットミスを防止

## Test plan
- [ ] HTMLエディタを開き、既存の `key: value` 形式の属性が正しく二分割表示されること
- [ ] key/valueそれぞれ独立して編集・幅自動調整されること
- [ ] `+` ボタンで `field: 説明` が追加されること
- [ ] 属性の削除・Undo/Redoが正常動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)