### PR TITLE
feat: 矢印キーで選択中ノードを移動

### DIFF
--- a/.claude/skills/conceptual-model/conceptual-model-template.html
+++ b/.claude/skills/conceptual-model/conceptual-model-template.html
@@ -976,6 +976,29 @@ document.addEventListener('keydown', e => {
     return;
   }
 
+  // 矢印キー: 選択中ノードを移動（親のdirectionに応じて）
+  if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key) && selectedPath && selectedPath.length > 0 && !isInputFocused()) {
+    const parent = getParentByPath(selectedPath);
+    if (!parent) return;
+    const dir = parent.direction || 'vertical';
+    const idx = selectedPath[selectedPath.length - 1];
+    let delta = 0;
+    if (dir === 'horizontal' && e.key === 'ArrowLeft') delta = -1;
+    if (dir === 'horizontal' && e.key === 'ArrowRight') delta = 1;
+    if (dir === 'vertical' && e.key === 'ArrowUp') delta = -1;
+    if (dir === 'vertical' && e.key === 'ArrowDown') delta = 1;
+    if (delta === 0) return;
+    const newIdx = idx + delta;
+    if (newIdx < 0 || newIdx >= parent.children.length) return;
+    e.preventDefault();
+    pushUndo();
+    const [removed] = parent.children.splice(idx, 1);
+    parent.children.splice(newIdx, 0, removed);
+    selectedPath = [...selectedPath.slice(0, -1), newIdx];
+    render();
+    return;
+  }
+
   // ⌘S: 手動保存（接続済みならすぐ保存、未接続ならConnect）
   if (isMeta && e.key === 's') {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- 選択中のノードを矢印キーで兄弟間移動できるようにした
- 親グループの `direction` に応じてキーをマッピング（horizontal→←→、vertical→↑↓）
- Undo対応済み、移動後も選択状態を維持

## Test plan
- [ ] horizontal親の子ノードを選択し、←→で並び順が変わること
- [ ] vertical親の子ノードを選択し、↑↓で並び順が変わること
- [ ] 端のノードで矢印キーを押しても何も起きないこと
- [ ] 移動後にUndo（⌘Z）で元に戻ること
- [ ] input入力中は矢印キーが通常のカーソル移動になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)