### PR TITLE
docs: サンプル概念モデルJSONを追加し、WF SKILL.mdのステップ番号を修正

### DIFF
--- a/.claude/skills/wireframe/SKILL.md
+++ b/.claude/skills/wireframe/SKILL.md
@@ -85,7 +85,7 @@ wireframe-skill-plusのスキーマに準拠する。詳細は `.claude/skills/w
 
 ## Execution Steps
 
-### Step 0: Conceptual Modelを読み込む
+### Step 1: Conceptual Modelを読み込む
 
 `docs/reqs/conceptual-model.json` が存在する場合は読み込む。
 エンティティ・属性の一覧を把握した上でwireframe JSONを生成する。
@@ -95,7 +95,7 @@ wireframe-skill-plusのスキーマに準拠する。詳細は `.claude/skills/w
 - ビュー情報（context・primaryType・entities）をトップレベルの `view` フィールドに記述する
 - `view.entities[].attributes` に conceptual-model.json から該当エンティティの全属性を埋め込む
 
-### Step 1: 認知モデルを読み込みJSONを生成
+### Step 2: 認知モデルを読み込みJSONを生成
 
 1. `.claude/skills/wireframe/wireframe-designer.md` を読み込む
 2. Phases 1–7の知覚シーケンスに従いレイアウトを推論する
@@ -108,13 +108,13 @@ wireframe-skill-plusのスキーマに準拠する。詳細は `.claude/skills/w
 - CSS flexboxに1:1対応する
 - ボタン・リンク・入力は固定 `width` 禁止（`height` のみ）
 
-### Step 2: JSONファイルを書き出す
+### Step 3: JSONファイルを書き出す
 
 ファイル名はJSON `name` フィールドからスラッグ化する（例: "タスク一覧" → `task-list`）。
 
 `docs/specs/wireframes/{screen-name}.wireframe.json` に書き出す。
 
-### Step 3: HTMLプレビューを生成（初回のみ）
+### Step 4: HTMLプレビューを生成（初回のみ）
 
 `docs/specs/wireframes/wireframe.html` が存在しない場合のみ生成する。
 
@@ -128,13 +128,13 @@ if not os.path.exists(html_path):
 "
 ```
 
-### Step 4: ブラウザで開く
+### Step 5: ブラウザで開く
 
 ```bash
 open docs/specs/wireframes/wireframe.html
 ```
 
-### Step 5: 完了報告
+### Step 6: 完了報告
 
 ```
 Wireframe generated:

--- a/docs/reqs/conceptual-model.json
+++ b/docs/reqs/conceptual-model.json
@@ -1,0 +1,174 @@
+{
+  "name": "プロジェクト管理ツール",
+  "root": {
+    "name": "プロジェクト管理",
+    "direction": "horizontal",
+    "children": [
+      {
+        "name": "組織",
+        "direction": "vertical",
+        "children": [
+          {
+            "name": "ワークスペース",
+            "type": "entity",
+            "attributes": [
+              "名前: ワークスペースの表示名",
+              "スラッグ: URL用の一意識別子",
+              "プラン: 契約プラン（free / pro / enterprise）"
+            ]
+          },
+          {
+            "name": "メンバー",
+            "type": "entity",
+            "attributes": [
+              "表示名: ユーザーの表示名",
+              "メール: ログイン用メールアドレス",
+              "ロール: ワークスペース内の権限（owner / admin / member）",
+              "アバター: プロフィール画像URL"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "プロジェクト管理",
+        "direction": "vertical",
+        "children": [
+          {
+            "name": "プロジェクト",
+            "type": "entity",
+            "attributes": [
+              "名前: プロジェクトの表示名",
+              "説明: プロジェクトの概要",
+              "ステータス: 進行状態（active / archived）",
+              "オーナー: プロジェクト責任者（メンバー）"
+            ]
+          },
+          {
+            "name": "タスク",
+            "type": "entity",
+            "attributes": [
+              "タイトル: タスクの件名",
+              "説明: タスクの詳細",
+              "ステータス: 進行状態（todo / in_progress / done）",
+              "優先度: 重要度（low / medium / high / urgent）",
+              "担当者: 割り当てられたメンバー",
+              "期限: 完了期限日"
+            ]
+          },
+          {
+            "name": "ラベル",
+            "type": "entity",
+            "attributes": [
+              "名前: ラベルの表示名",
+              "色: 表示カラーコード"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "コミュニケーション",
+        "direction": "vertical",
+        "children": [
+          {
+            "name": "コメント",
+            "type": "entity",
+            "attributes": [
+              "本文: コメントの内容（Markdown）",
+              "投稿者: コメントしたメンバー",
+              "投稿日時: コメントの作成日時"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "views": [
+    {
+      "name": "プロジェクト一覧",
+      "context": "一覧",
+      "primaryType": "card",
+      "entities": [
+        {
+          "entity": "プロジェクト",
+          "role": "primary"
+        },
+        {
+          "entity": "メンバー",
+          "role": "avatar"
+        }
+      ]
+    },
+    {
+      "name": "プロジェクト詳細",
+      "context": "詳細",
+      "primaryType": "card",
+      "entities": [
+        {
+          "entity": "プロジェクト",
+          "role": "primary"
+        },
+        {
+          "entity": "タスク",
+          "role": "list"
+        },
+        {
+          "entity": "メンバー",
+          "role": "avatar"
+        }
+      ]
+    },
+    {
+      "name": "タスクボード",
+      "context": "一覧",
+      "primaryType": "table",
+      "entities": [
+        {
+          "entity": "タスク",
+          "role": "primary"
+        },
+        {
+          "entity": "ラベル",
+          "role": "tag"
+        },
+        {
+          "entity": "メンバー",
+          "role": "avatar"
+        }
+      ]
+    },
+    {
+      "name": "タスク詳細",
+      "context": "詳細",
+      "primaryType": "card",
+      "entities": [
+        {
+          "entity": "タスク",
+          "role": "primary"
+        },
+        {
+          "entity": "コメント",
+          "role": "list"
+        },
+        {
+          "entity": "ラベル",
+          "role": "tag"
+        }
+      ]
+    },
+    {
+      "name": "メンバー管理",
+      "context": "一覧",
+      "primaryType": "table",
+      "entities": [
+        {
+          "entity": "メンバー",
+          "role": "primary"
+        },
+        {
+          "entity": "ワークスペース",
+          "role": "context"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- プロジェクト管理ツールを題材にしたサンプル `conceptual-model.json` を追加
- WF SKILL.mdのStep番号を0始まりから1始まりに修正

## Test plan
- [ ] `conceptual-model.html` を開き、`conceptual-model.json` をドロップして正しく読み込めることを確認
- [ ] エンティティ（ワークスペース、メンバー、プロジェクト、タスク、ラベル、コメント）が表示されることを確認
- [ ] ビュー定義（5件）が右ペインに表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)