### PR TITLE
ルールファイルを統合JSONスキーマに合わせて更新

### DIFF
--- a/.claude/rules/docs.md
+++ b/.claude/rules/docs.md
@@ -14,14 +14,18 @@ paths:
 - 詳細は `.claude/rules/workflow.md` を参照する
 
 
-## Conceptual Model（JSON + HTMLエディタ）
+## Conceptual Model（統合JSON + HTMLエディタ）
 
-- `conceptual-model.json` はConceptual Model HTMLで更新する。直接編集も可だが、HTMLエディタを使うことを推奨
+- `conceptual-model.json` は統合JSON（entities/actors/composites/screens/navigation）
+- CMエディタ（`conceptual-model.html`）で entities/actors/composites を編集
+- Screensエディタ（`screens.html`）で screens/navigation を編集
+- 両エディタは同じJSONを共有し、担当外フィールドをパススルーで保持する
 - ユーザーから設計指示があった場合、`conceptual-model.json` の変更が `ui-spec.md` と `db-schema.md` に影響しないか確認する
 - `conceptual-model.json` が更新されたら、`conceptual-model.md` も整合するよう更新する
 
-## Wireframe（JSON + HTMLエディタ）
+## Screens（統合JSON内）
 
-- `wireframe.json` の `_entity`/`_attributes` は編集しない。変更は `conceptual-model.json` から
-- ビューの追加は Conceptual Model HTML の右ペインで行う（auto-saveで `conceptual-model.json` に保存される）
-- `wireframe.json` が更新されたら、`ui-spec.md` への影響を確認する
+- 画面定義は `conceptual-model.json` の `screens` / `navigation` で管理する
+- 画面を追加するときは `/wireframe` でScreensエディタを開いて編集する
+- screens の objects.crud は actors の touches 権限の範囲内で設定する
+- screens が更新されたら、`ui-spec.md` への影響を確認する

--- a/.claude/rules/ui-design.md
+++ b/.claude/rules/ui-design.md
@@ -10,21 +10,21 @@ paths:
 ## 基本原則
 - UIはOOUI（オブジェクト指向UI）に従って設計する
 - タスク（動詞）ではなくオブジェクト（名詞）を起点にする
-- オブジェクトは必ず `docs/reqs/conceptual-model.md` のエンティティから導出する
+- オブジェクトは必ず `conceptual-model.json` の entities から導出する
 
 ## オブジェクト定義の手順
-1. `docs/reqs/conceptual-model.md` のエンティティ一覧を読む
+1. `conceptual-model.json` の entities 一覧を読む
 2. 各エンティティをOOUIのオブジェクトに対応させる
 3. 各オブジェクトの「表示する属性」と「アクション」を定義する
 4. `docs/specs/ui-spec.md` のオブジェクト定義セクションに記述する
 
 ## 画面階層の導出ルール
-- 各エンティティは原則「コレクション画面」と「シングル画面」を持つ
-- conceptual-modelの関係（1:N）がネスト構造に対応する
-- ネストは原則2階層まで。それ以上は設計を疑う
-- 独立した画面を持つか否かは、ユーザーがそのエンティティを直接操作するかで判断する
+- `conceptual-model.json` の screens が画面定義の正
+- 各screenの objects が collection（一覧）か single（詳細/フォーム）かで画面種別が決まる
+- actors の touches 権限が画面で実行可能な操作を制約する
+- 独立した画面を持つか否かは、actors がそのエンティティを直接操作するかで判断する
 
 ## 実装時のルール
-- 新しい画面を追加するときは conceptual-model の画面階層を先に更新する
-- conceptual-modelにないエンティティの画面を作らない。先にPRDに戻る
+- 新しい画面を追加するときは conceptual-model.json の screens を先に更新する
+- conceptual-model.json にないエンティティの画面を作らない。先にPRDに戻る
 - ui-spec の状態定義（Loading/Empty/Error/Success）を必ず実装する

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -13,31 +13,31 @@
 ### 1. PG / PRD / MRD → Conceptual Model
 - **トリガー**: PRD・MRDが固まり、概念モデルの作成・更新に入るとき
 - **アクション**: `/conceptual-model` を実行
-- **完了条件**: `conceptual-model.json` にエンティティ + ビュー定義が揃っている
+- **完了条件**: `conceptual-model.json` に entities + actors が揃っている
 
-### 2. Conceptual Model → Wireframe
-- **トリガー**: `conceptual-model.json` にビュー情報があり、ワイヤーフレームが必要なとき
-- **アクション**: `/wireframe` を各ビューに対して実行
-- **完了条件**: 各ビューの `{screen-name}.wireframe.json` が生成されている
+### 2. Conceptual Model → Screens
+- **トリガー**: `conceptual-model.json` に entities・actors が定義され、画面設計に入るとき
+- **アクション**: `/wireframe` を実行
+- **完了条件**: `conceptual-model.json` の screens + navigation が定義されている
 
-### 3. Wireframe 完了後 → 並列で進める
+### 3. Screens 完了後 → 並列で進める
 
-Wireframe完了後、以下の2トラックを並列で進める。
+Screens完了後、以下の2トラックを並列で進める。
 
 #### Track A: Specs（設計仕様群）を順次導出
 
 | 順序 | Spec | 導出元 | ファイル |
 |---|---|---|---|
-| 1 | DB Schema | conceptual-model.json | `docs/specs/db-schema.md` |
+| 1 | DB Schema | conceptual-model.json（entities） | `docs/specs/db-schema.md` |
 | 2 | API Spec | db-schema + conceptual-model + prd | `docs/specs/api-spec.md` |
-| 3 | Auth Spec | api-spec + prd（ロール定義） | `docs/specs/auth-spec.md` |
-| 4 | UI Spec | wireframe.json + api-spec + conceptual-model | `docs/specs/ui-spec.md` |
+| 3 | Auth Spec | api-spec + conceptual-model（actors） | `docs/specs/auth-spec.md` |
+| 4 | UI Spec | conceptual-model（screens）+ api-spec | `docs/specs/ui-spec.md` |
 | 5 | Analytics Spec | product-goals | `docs/specs/analytics-spec.md` |
 | 5 | Infra Spec | 上記specsの要件 | `docs/specs/infra-spec.md` |
 
 #### Track B: User Stories → Test Spec
 
-1. **User Stories**: ワイヤーフレームと概念モデルを参照して `docs/reqs/user-stories.md` を更新。各ストーリーに受け入れ条件とシナリオ（Gherkin）を定義
+1. **User Stories**: screens定義と概念モデルを参照して `docs/reqs/user-stories.md` を更新。各ストーリーに受け入れ条件とシナリオ（Gherkin）を定義
 2. **Test Spec**: ユーザーストーリーの受け入れ条件から `docs/specs/test-spec.md` を導出
 
 ### 4. Impl Plan
@@ -51,9 +51,9 @@ Wireframe完了後、以下の2トラックを並列で進める。
 
 #### 実装時の制約
 - DBを変更する前に `docs/reqs/conceptual-model.md` を確認する
-- `conceptual-model.md` にないエンティティをDBに追加しない。先にPRDに戻る
+- `conceptual-model.json` にないエンティティをDBに追加しない。先にPRDに戻る
 - APIを追加するときは `docs/specs/api-spec.md` の命名規則に従い、対応するPRD機能を明記する
-- 画面を追加するときは conceptual-modelとwireframe を先に追加/更新する
+- 画面を追加するときは conceptual-model.json の screens を先に追加/更新する
 - イベント計測を追加するときは `docs/specs/analytics-spec.md` のイベント命名規則に従う
 
 ## スキップのルール


### PR DESCRIPTION
## Summary
- workflow.md: Wireframe→Screens遷移に変更
- docs.md: Wireframeセクション→Screensセクション、パススルールール追記
- ui-design.md: 画面階層の導出をscreens/actors参照に変更

## Test plan
- [ ] workflow.mdのフローが新スキーマと整合していることを確認
- [ ] docs.mdのルールが新エディタの動作と一致していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)