### PR TITLE
CLAUDE.mdファイル群を統合JSONスキーマに合わせて更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@
 - 市場・ユーザー定義: @docs/reqs/mrd.md
 - 提供価値・機能定義: @docs/reqs/prd.md
 - 概念モデル（設計意図）: @docs/reqs/conceptual-model.md
-- 概念モデル（構造定義）: @docs/reqs/conceptual-model.json
+- 概念モデル（統合JSON）: @docs/reqs/conceptual-model.json — entities/actors/composites/screens/navigation
 - ユーザーストーリー: @docs/reqs/user-stories.md
 
 ### 設計（specs/ — reqs/ から導出）

--- a/docs/reqs/CLAUDE.md
+++ b/docs/reqs/CLAUDE.md
@@ -13,8 +13,8 @@
 | pg0.md (pg1.md ...) | Product Goalごとのスコープ・出口条件（WHEN） | 全員 |
 | mrd.md | 市場構造・購入者・参入戦略（WHERE, WHO:Buyer, HOW MUCH） | PMMとPdM |
 | prd.md | 利用者・提供価値・機能定義・スコープ（WHY, WHO:User ,WHAT） | PdMとPMM・開発 |
-| conceptual-model.md | エンティティ・関係・画面階層（Model of WHAT） | 開発 |
-| conceptual-model.json | エンティティ＋ビュー定義（Conceptual Model HTMLで操作） | 開発 |
+| conceptual-model.md | エンティティ・関係の設計意図（Model of WHAT） | 開発 |
+| conceptual-model.json | 統合JSON: entities/actors/composites/screens/navigation（HTMLエディタで操作） | 開発 |
 | user-stories.md | ユーザーストーリーと受け入れ条件（WHAT to develop） | QA・開発 |
 
 ## 編集ルール
@@ -23,6 +23,6 @@
 - WHO は Buyer（mrd.md）と User（prd.md）に分離して定義する
 - 3つがある程度固まってから conceptual-model.md に降ろす
 - 新しいエンティティを追加する前に conceptual-model.md を更新する
-- 新しい画面を追加する前に conceptual-model.md の画面階層を更新する
+- 新しい画面を追加する前に conceptual-model.json の screens を更新する
 - 現在のPGに含まない機能は記述しない（product-goals.md + 該当PGファイルを確認）
 - product-goals.md の確信度が「—」のセクションは記述しない

--- a/docs/specs/CLAUDE.md
+++ b/docs/specs/CLAUDE.md
@@ -9,11 +9,10 @@
 
 | ファイル | 責務 | 導出元 |
 |---|---|---|
-| db-schema.md | テーブル定義・制約・マイグレーション | reqs/conceptual-model.md |
-| api-spec.md | エンドポイント定義・リクエスト/レスポンス形式 | reqs/prd.md, reqs/conceptual-model.md |
-| auth-spec.md | 認証・認可フロー・ロール定義 | reqs/prd.md |
-| ui-spec.md | フロントエンド実装仕様・状態定義 | reqs/conceptual-model.md, reqs/prd.md |
-| {screen}.wireframe.json | 各画面のレイアウト定義（Wireframe HTMLで操作） | 開発 |
+| db-schema.md | テーブル定義・制約・マイグレーション | reqs/conceptual-model.json（entities） |
+| api-spec.md | エンドポイント定義・リクエスト/レスポンス形式 | reqs/prd.md, reqs/conceptual-model.json |
+| auth-spec.md | 認証・認可フロー・ロール定義 | reqs/conceptual-model.json（actors） |
+| ui-spec.md | フロントエンド実装仕様・状態定義 | reqs/conceptual-model.json（screens）, reqs/prd.md |
 | analytics-spec.md | 計測設計・イベント定義 | reqs/product-goals.md |
 | infra-spec.md | 検証環境のインフラ構成定義 | local環境を調査 |
 | test-spec.md | テスト計画・シナリオテスト | reqs/user-stories.md + 全specs |
@@ -22,6 +21,6 @@
 ## 編集ルール
 
 - 実装は必ずこのディレクトリのファイルを参照する（reqs/ を直接パースしない）
-- conceptual-model.md にないエンティティを db-schema.md に追加しない
+- conceptual-model.json にないエンティティを db-schema.md に追加しない
 - api-spec.md に追加するときは対応する PRD 機能を明記する
 - ui-spec.md の状態定義（Loading/Empty/Error/Success）を必ず実装する


### PR DESCRIPTION
## Summary
- CLAUDE.md: Docs mapのconceptual-model.json説明を更新
- docs/reqs/CLAUDE.md: conceptual-model.jsonの責務を統合JSONに
- docs/specs/CLAUDE.md: wireframe.json行を削除、導出元を更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)