### PR TITLE
.gitignoreを整理し旧wireframeエントリを削除

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,4 @@ __pycache__/
 CLAUDE.local.md
 .claude/settings.local.json
 docs/reqs/conceptual-model.html
-docs/specs/wireframes/*.html
-docs/specs/wireframes/test.wireframe.json
-docs/specs/wireframes/sample.wireframe.json
+docs/reqs/screens.html


### PR DESCRIPTION
## Summary
- 旧wireframe関連のignoreエントリを削除
- screens.html（生成物）をignoreに追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)