### PR TITLE
docs: /wireframe の出力先記述を統合JSONに修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ project_root/
 
 順序：`pg0 ⇔ prd ⇔ mrd → conceptual-model → wireframe`
 
-pg0・prd・mrd は Claude Code と対話しながらつくる。Agent Teams を使えば対話・調査・分析を並列で進められる。3つが固まったら `/conceptual-model` で概念モデル（JSON + HTMLエディタ）を生成、ビュー定義後 `/wireframe` で各画面のレイアウトを生成する。HTMLエディタで微調整も可能。
+pg0・prd・mrd は Claude Code と対話しながらつくる。Agent Teams を使えば対話・調査・分析を並列で進められる。3つが固まったら `/conceptual-model` で概念モデル（entities/actors/composites）を生成、続けて `/wireframe` で画面定義（screens/navigation）を生成する。いずれも同じ `conceptual-model.json` に格納され、HTMLエディタで微調整も可能。
 
 **conceptual-model 以降は、Claude Code が生成し人が確認・調整するスタイルに変わる。**
 
@@ -167,9 +167,9 @@ product-goals（PG一覧・確信度）
    pg0 ⇔ prd（WHO:User, WHY, WHAT） ⇔ mrd（WHERE, WHO:Buyer, HOW MUCH）
         │                                          ↑ Claude Codeと対話しながらつくる
         │
-  conceptual-model.json（エンティティ・ビュー定義）  ← /conceptual-model で生成
+  conceptual-model.json（entities/actors）           ← /conceptual-model で生成
         │
-  wireframes/{screen}.wireframe.json（レイアウト）   ← /wireframe で生成
+  conceptual-model.json（screens/navigation）        ← /wireframe で生成
         │                                          ↑ ここからClaude Codeが生成、人が調整
         │
    user-stories

--- a/docs/specs/db-schema.md
+++ b/docs/specs/db-schema.md
@@ -5,7 +5,7 @@
 **バージョン:** 0.1
 **ステータス:** Draft
 **最終更新:** {日付}
-**導出元:** docs/reqs/conceptual-model.md
+**導出元:** docs/reqs/conceptual-model.json（entities）
 
 ---
 


### PR DESCRIPTION
## Summary
- README.md: `/wireframe` の出力先を旧 `wireframes/*.wireframe.json` から `conceptual-model.json（screens/navigation）` に修正
- db-schema.md: 導出元を `conceptual-model.md` から `conceptual-model.json（entities）` に修正

## Test plan
- [ ] README.mdのドキュメントの流れ図が現状のワークフローと一致していること
- [ ] db-schema.mdの導出元がdocs/specs/CLAUDE.mdの記述と一致していること

🤖 Generated with [Claude Code](https://claude.com/claude-code)