### PR TITLE
dirtyRefでEditedインジケーターの誤表示を修正

### DIFF
--- a/docs/reqs/screen-editor.html
+++ b/docs/reqs/screen-editor.html
@@ -385,8 +385,10 @@ const TABS=[{id:"map",label:"Map"},{id:"detail",label:"Screen"}];
 function App(){
   const[screens,setScreensRaw]=useState(EMPTY),[view,setView]=useState("map"),[scrId,setScrId]=useState(null);
   const histRef=useRef({stack:[EMPTY],idx:0});
+  const dirtyRef=useRef(false);
 
   const setScreens=useCallback(updater=>{
+    dirtyRef.current=true;
     setScreensRaw(prev=>{
       const next=typeof updater==='function'?updater(prev):updater;
       const h=histRef.current;
@@ -400,8 +402,8 @@ function App(){
     setScreensRaw(prev=>typeof updater==='function'?updater(prev):updater);
   },[]);
 
-  const undo=useCallback(()=>{const h=histRef.current;if(h.idx<=0)return;h.idx--;setScreensRaw(JSON.parse(JSON.stringify(h.stack[h.idx])));showToast('Undo');},[]);
-  const redo=useCallback(()=>{const h=histRef.current;if(h.idx>=h.stack.length-1)return;h.idx++;setScreensRaw(JSON.parse(JSON.stringify(h.stack[h.idx])));showToast('Redo');},[]);
+  const undo=useCallback(()=>{const h=histRef.current;if(h.idx<=0)return;h.idx--;dirtyRef.current=true;setScreensRaw(JSON.parse(JSON.stringify(h.stack[h.idx])));showToast('Undo');},[]);
+  const redo=useCallback(()=>{const h=histRef.current;if(h.idx>=h.stack.length-1)return;h.idx++;dirtyRef.current=true;setScreensRaw(JSON.parse(JSON.stringify(h.stack[h.idx])));showToast('Redo');},[]);
   // Map View からの選択状態参照用
   const selRef=useRef({scrId:null,navId:null,actorId:null});
   const clipRef=useRef(null);
@@ -455,8 +457,7 @@ function App(){
     return()=>{window.__scUndo=window.__scRedo=window.__scDelete=window.__scCopy=window.__scPaste=window.__scCut=null;};
   },[undo,redo,handleDelete,handleCopy,handlePaste,handleCut]);
 
-  const initialLoad=useRef(true);
-  useEffect(()=>{screensRef=screens;if(initialLoad.current){initialLoad.current=false;}else{markModified();}},[screens]);
+  useEffect(()=>{screensRef=screens;if(dirtyRef.current){dirtyRef.current=false;markModified();}},[screens]);
   useEffect(()=>{
     window.__scLoadData=d=>{
       const scData=ensureScreenPositions(splitData(d));


### PR DESCRIPTION
## Summary
- ノード選択だけでEditedが表示される問題の根本修正
- `dirtyRef` フラグを導入し、`setScreens`（履歴記録）/ `undo` / `redo` でのみフラグを立てる
- `setScreensSilent`（ドラッグ中間更新）やファイル読み込みではEditedを表示しない
- 不要になった `initialLoad` refを `dirtyRef` に統合

## Test plan
- [ ] ノードをクリック（選択のみ）→ Editedが表示されないこと
- [ ] ノードをドラッグ移動 → Editedが表示されること
- [ ] サイドシートで名前変更 → Editedが表示されること
- [ ] Undo/Redo → Editedが表示されること
- [ ] JSONファイル読み込み直後 → Editedが表示されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)