### PR TITLE
fix: リレーションラベルの幅を文字種に応じて可変に

### DIFF
--- a/docs/reqs/lib/shared.js
+++ b/docs/reqs/lib/shared.js
@@ -61,10 +61,16 @@
     return { cx: (minX + maxX) / 2, cy: (minY + maxY) / 2 };
   };
 
-  // 文字が全角（CJK等）かどうか判定
+  // East Asian Width が Wide/Fullwidth の主要範囲を判定
   exports.isWideChar = function(ch) {
     var code = ch.charCodeAt(0);
-    return code > 0x024F;
+    return (code >= 0x1100 && code <= 0x115F) ||  // ハングル Jamo
+           (code >= 0x2E80 && code <= 0x9FFF) ||  // CJK部首〜CJK統合漢字
+           (code >= 0xAC00 && code <= 0xD7AF) ||  // ハングル音節
+           (code >= 0xF900 && code <= 0xFAFF) ||  // CJK互換漢字
+           (code >= 0xFE30 && code <= 0xFE6F) ||  // CJK互換形
+           (code >= 0xFF01 && code <= 0xFF60) ||  // 全角英数
+           (code >= 0xFFE0 && code <= 0xFFE6);    // 全角記号
   };
 
   // ラベル幅の計算（半角・全角を考慮）

--- a/docs/reqs/lib/shared.test.js
+++ b/docs/reqs/lib/shared.test.js
@@ -122,8 +122,38 @@ describe('isWideChar', () => {
     expect(isWideChar('a')).toBe(false);
   });
 
-  it('日本語文字はtrue', () => {
+  it('数字・記号はfalse', () => {
+    expect(isWideChar('0')).toBe(false);
+    expect(isWideChar(':')).toBe(false);
+    expect(isWideChar('-')).toBe(false);
+  });
+
+  it('ギリシャ文字(U+03B1)はfalse', () => {
+    expect(isWideChar('\u03B1')).toBe(false);
+  });
+
+  it('キリル文字(U+0411)はfalse', () => {
+    expect(isWideChar('\u0411')).toBe(false);
+  });
+
+  it('CJK統合漢字の先頭(U+4E00)はtrue', () => {
+    expect(isWideChar('\u4E00')).toBe(true);
+  });
+
+  it('ひらがな(U+3042)はtrue', () => {
     expect(isWideChar('あ')).toBe(true);
+  });
+
+  it('カタカナ(U+30A2)はtrue', () => {
+    expect(isWideChar('ア')).toBe(true);
+  });
+
+  it('全角英数(U+FF21)はtrue', () => {
+    expect(isWideChar('\uFF21')).toBe(true);
+  });
+
+  it('ハングル音節(U+AC00)はtrue', () => {
+    expect(isWideChar('\uAC00')).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- `labelWidth` を半角固定幅(7px)から半角(7px)/全角(11px)の文字種別計算に変更
- 日本語ラベル（「テナント内ユーザ」等）が背景ボックスからはみ出す問題を修正
- model-editor / screen-editor 両方に共通で適用

## Test plan
- [x] `shared.test.js` に日本語・混在テキストのテストケースを追加し、全テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)