### PR TITLE
docs: sample.product-model.jsonをPMツールサンプルに整理

### DIFF
--- a/docs/reqs/sample.product-model.json
+++ b/docs/reqs/sample.product-model.json
@@ -17,8 +17,8 @@
           "label": "has"
         }
       ],
-      "x": 37,
-      "y": 87
+      "x": 80,
+      "y": 80
     },
     {
       "id": "member",
@@ -37,8 +37,8 @@
           "label": "posted"
         }
       ],
-      "x": 350,
-      "y": 146
+      "x": 400,
+      "y": 80
     },
     {
       "id": "project",
@@ -57,8 +57,8 @@
           "label": "assigned"
         }
       ],
-      "x": 685,
-      "y": 0
+      "x": 720,
+      "y": 80
     },
     {
       "id": "task",
@@ -77,29 +77,22 @@
           "label": "tagged"
         }
       ],
-      "x": 909,
-      "y": 202
+      "x": 400,
+      "y": 280
     },
     {
       "id": "label",
       "name": "ラベル",
       "relations": [],
-      "x": 553,
-      "y": 230
+      "x": 720,
+      "y": 280
     },
     {
       "id": "comment",
       "name": "コメント",
       "relations": [],
-      "x": 396,
-      "y": 427
-    },
-    {
-      "id": "use735",
-      "name": "ああああああああああああああああ",
-      "x": 117,
-      "y": 276.5,
-      "relations": []
+      "x": 80,
+      "y": 280
     }
   ],
   "actors": [
@@ -110,127 +103,55 @@
         {
           "entityId": "workspace",
           "crud": [
-            {
-              "op": "C",
-              "scope": "own"
-            },
-            {
-              "op": "R",
-              "scope": "own"
-            },
-            {
-              "op": "U",
-              "scope": "own"
-            },
-            {
-              "op": "D",
-              "scope": "own"
-            }
+            { "op": "C", "scope": "own" },
+            { "op": "R", "scope": "own" },
+            { "op": "U", "scope": "own" },
+            { "op": "D", "scope": "own" }
           ]
         },
         {
           "entityId": "project",
           "crud": [
-            {
-              "op": "C",
-              "scope": "own"
-            },
-            {
-              "op": "R",
-              "scope": "own"
-            },
-            {
-              "op": "U",
-              "scope": "own"
-            },
-            {
-              "op": "D",
-              "scope": "own"
-            }
+            { "op": "C", "scope": "own" },
+            { "op": "R", "scope": "own" },
+            { "op": "U", "scope": "own" },
+            { "op": "D", "scope": "own" }
           ]
         },
         {
           "entityId": "task",
           "crud": [
-            {
-              "op": "C",
-              "scope": "all"
-            },
-            {
-              "op": "R",
-              "scope": "all"
-            },
-            {
-              "op": "U",
-              "scope": "all"
-            },
-            {
-              "op": "D",
-              "scope": "all"
-            }
+            { "op": "C", "scope": "all" },
+            { "op": "R", "scope": "all" },
+            { "op": "U", "scope": "all" },
+            { "op": "D", "scope": "all" }
           ]
         },
         {
           "entityId": "member",
           "crud": [
-            {
-              "op": "C",
-              "scope": "all"
-            },
-            {
-              "op": "R",
-              "scope": "all"
-            },
-            {
-              "op": "U",
-              "scope": "all"
-            },
-            {
-              "op": "D",
-              "scope": "all"
-            }
+            { "op": "C", "scope": "all" },
+            { "op": "R", "scope": "all" },
+            { "op": "U", "scope": "all" },
+            { "op": "D", "scope": "all" }
           ]
         },
         {
           "entityId": "label",
           "crud": [
-            {
-              "op": "C",
-              "scope": "all"
-            },
-            {
-              "op": "R",
-              "scope": "all"
-            },
-            {
-              "op": "U",
-              "scope": "all"
-            },
-            {
-              "op": "D",
-              "scope": "all"
-            }
+            { "op": "C", "scope": "all" },
+            { "op": "R", "scope": "all" },
+            { "op": "U", "scope": "all" },
+            { "op": "D", "scope": "all" }
           ]
         },
         {
           "entityId": "comment",
           "crud": [
-            {
-              "op": "C",
-              "scope": "all"
-            },
-            {
-              "op": "R",
-              "scope": "all"
-            },
-            {
-              "op": "U",
-              "scope": "all"
-            },
-            {
-              "op": "D",
-              "scope": "all"
-            }
+            { "op": "C", "scope": "all" },
+            { "op": "R", "scope": "all" },
+            { "op": "U", "scope": "all" },
+            { "op": "D", "scope": "all" }
           ]
         }
       ]
@@ -242,70 +163,36 @@
         {
           "entityId": "project",
           "crud": [
-            {
-              "op": "R",
-              "scope": "all"
-            }
+            { "op": "R", "scope": "all" }
           ]
         },
         {
           "entityId": "task",
           "crud": [
-            {
-              "op": "C",
-              "scope": "all"
-            },
-            {
-              "op": "R",
-              "scope": "all"
-            },
-            {
-              "op": "U",
-              "scope": "all"
-            },
-            {
-              "op": "D",
-              "scope": "own"
-            }
+            { "op": "C", "scope": "all" },
+            { "op": "R", "scope": "all" },
+            { "op": "U", "scope": "all" }
           ]
         },
         {
           "entityId": "comment",
           "crud": [
-            {
-              "op": "C",
-              "scope": "own"
-            },
-            {
-              "op": "R",
-              "scope": "all"
-            },
-            {
-              "op": "U",
-              "scope": "own"
-            },
-            {
-              "op": "D",
-              "scope": "own"
-            }
+            { "op": "C", "scope": "own" },
+            { "op": "R", "scope": "all" },
+            { "op": "U", "scope": "own" },
+            { "op": "D", "scope": "own" }
           ]
         },
         {
           "entityId": "label",
           "crud": [
-            {
-              "op": "R",
-              "scope": "all"
-            }
+            { "op": "R", "scope": "all" }
           ]
         },
         {
           "entityId": "member",
           "crud": [
-            {
-              "op": "R",
-              "scope": "all"
-            }
+            { "op": "R", "scope": "all" }
           ]
         }
       ]
@@ -314,277 +201,176 @@
   "screens": [
     {
       "id": "owner-dashboard",
-      "name": "オーナーダッシュボード",
+      "name": "ダッシュボード",
       "actorId": "owner",
-      "objects": [
-        {
-          "id": "co1",
-          "entityId": "project",
-          "variant": "collection",
-          "crud": [
-            "R"
-          ]
-        },
-        {
-          "id": "co2",
-          "entityId": "task",
-          "variant": "collection",
-          "crud": [
-            "R"
-          ]
-        },
-        {
-          "id": "co3",
-          "entityId": "member",
-          "variant": "collection",
-          "crud": [
-            "R"
-          ]
-        }
-      ],
+      "type": "composite",
       "prompt": "KPI（月次進捗・タスク完了率）をカード形式で上部に表示。プロジェクト別タスク数をグラフで中段に。",
-      "x": 147,
-      "y": -67,
-      "type": "composite"
+      "objects": [
+        { "id": "co1", "entityId": "project", "variant": "collection", "crud": ["R"] },
+        { "id": "co2", "entityId": "task", "variant": "collection", "crud": ["R"] },
+        { "id": "co3", "entityId": "member", "variant": "collection", "crud": ["R"] }
+      ],
+      "x": 100,
+      "y": -80
     },
     {
       "id": "project-list",
       "name": "プロジェクト一覧",
       "actorId": "owner",
-      "x": -173,
-      "y": -6,
-      "prompt": "",
+      "type": "screen",
+      "prompt": "プロジェクトをカード形式で一覧表示。新規作成ボタン付き。",
       "objects": [
-        {
-          "id": "o1",
-          "entityId": "project",
-          "variant": "collection",
-          "crud": [
-            "C",
-            "R",
-            "D"
-          ]
-        }
+        { "id": "o1", "entityId": "project", "variant": "collection", "crud": ["C", "R", "D"] }
       ],
-      "type": "screen"
+      "x": -300,
+      "y": 60
     },
     {
       "id": "project-detail",
       "name": "プロジェクト詳細",
       "actorId": "owner",
-      "x": -26,
-      "y": 259,
+      "type": "screen",
       "prompt": "タスク一覧をカンバン形式で表示。メンバー一覧サイドパネル付き。",
       "objects": [
-        {
-          "id": "o2",
-          "entityId": "project",
-          "variant": "collection",
-          "crud": [
-            "U",
-            "R"
-          ],
-          "area": "top"
-        },
-        {
-          "id": "o3",
-          "entityId": "task",
-          "variant": "collection",
-          "crud": [
-            "C",
-            "R",
-            "U",
-            "D"
-          ]
-        },
-        {
-          "id": "o4",
-          "entityId": "member",
-          "variant": "collection",
-          "crud": [
-            "C",
-            "R",
-            "D"
-          ],
-          "area": "right"
-        },
-        {
-          "id": "i6d03v",
-          "entityId": "workspace",
-          "variant": "collection",
-          "crud": [
-            "R"
-          ],
-          "area": "main"
-        }
+        { "id": "o2", "entityId": "project", "variant": "single", "crud": ["R", "U"] },
+        { "id": "o3", "entityId": "task", "variant": "collection", "crud": ["C", "R", "U", "D"] },
+        { "id": "o4", "entityId": "member", "variant": "collection", "crud": ["C", "R", "D"] }
       ],
-      "type": "screen"
+      "x": 0,
+      "y": 260
     },
     {
       "id": "task-detail",
       "name": "タスク詳細",
       "actorId": "owner",
-      "x": 41,
-      "y": 536,
+      "type": "screen",
       "prompt": "タスクの編集フォームとコメントスレッド。ラベル選択はタグピッカー。",
       "objects": [
-        {
-          "id": "o5",
-          "entityId": "task",
-          "variant": "single",
-          "crud": [
-            "R",
-            "U",
-            "D"
-          ]
-        },
-        {
-          "id": "o6",
-          "entityId": "comment",
-          "variant": "collection",
-          "crud": [
-            "C",
-            "R",
-            "D"
-          ]
-        },
-        {
-          "id": "o7",
-          "entityId": "label",
-          "variant": "collection",
-          "crud": [
-            "R"
-          ]
-        }
+        { "id": "o5", "entityId": "task", "variant": "single", "crud": ["R", "U", "D"] },
+        { "id": "o6", "entityId": "comment", "variant": "collection", "crud": ["C", "R", "D"] },
+        { "id": "o7", "entityId": "label", "variant": "collection", "crud": ["R"] }
       ],
-      "type": "screen"
+      "x": 0,
+      "y": 500
     },
     {
-      "id": "member-task-list",
+      "id": "member-management",
+      "name": "メンバー管理",
+      "actorId": "owner",
+      "type": "screen",
+      "prompt": "ワークスペースのメンバー一覧。招待・削除・ロール変更。",
+      "objects": [
+        { "id": "o11", "entityId": "member", "variant": "collection", "crud": ["C", "R", "U", "D"] }
+      ],
+      "x": -600,
+      "y": 60
+    },
+    {
+      "id": "label-management",
+      "name": "ラベル管理",
+      "actorId": "owner",
+      "type": "screen",
+      "prompt": "ラベルの作成・編集・削除。色とテキストを設定。",
+      "objects": [
+        { "id": "o12", "entityId": "label", "variant": "collection", "crud": ["C", "R", "U", "D"] }
+      ],
+      "x": -600,
+      "y": 260
+    },
+    {
+      "id": "member-my-tasks",
       "name": "マイタスク",
       "actorId": "member-actor",
-      "x": 60,
-      "y": 60,
+      "type": "screen",
       "prompt": "自分にアサインされたタスクを期限順に表示。",
       "objects": [
-        {
-          "id": "o8",
-          "entityId": "task",
-          "variant": "collection",
-          "crud": [
-            "C",
-            "R",
-            "U"
-          ]
-        },
-        {
-          "id": "9kxq6u",
-          "entityId": "member",
-          "variant": "collection",
-          "crud": [
-            "R"
-          ]
-        }
+        { "id": "o8", "entityId": "task", "variant": "collection", "crud": ["C", "R", "U"] },
+        { "id": "o13", "entityId": "member", "variant": "collection", "crud": ["R"] }
       ],
-      "type": "screen"
+      "x": 60,
+      "y": 60
+    },
+    {
+      "id": "member-project-board",
+      "name": "プロジェクトボード",
+      "actorId": "member-actor",
+      "type": "screen",
+      "prompt": "参加プロジェクトのタスクをカンバン形式で表示。",
+      "objects": [
+        { "id": "o14", "entityId": "project", "variant": "single", "crud": ["R"] },
+        { "id": "o15", "entityId": "task", "variant": "collection", "crud": ["C", "R", "U"] }
+      ],
+      "x": -300,
+      "y": 60
     },
     {
       "id": "member-task-detail",
       "name": "タスク詳細",
       "actorId": "member-actor",
+      "type": "screen",
+      "prompt": "タスクの閲覧・編集とコメント投稿。",
+      "objects": [
+        { "id": "o9", "entityId": "task", "variant": "single", "crud": ["R", "U"] },
+        { "id": "o10", "entityId": "comment", "variant": "collection", "crud": ["C", "R", "D"] }
+      ],
       "x": 60,
-      "y": 280,
-      "prompt": "",
-      "objects": [
-        {
-          "id": "o9",
-          "entityId": "task",
-          "variant": "single",
-          "crud": [
-            "R",
-            "U"
-          ]
-        },
-        {
-          "id": "o10",
-          "entityId": "comment",
-          "variant": "collection",
-          "crud": [
-            "C",
-            "R",
-            "D"
-          ],
-          "area": "right"
-        }
-      ],
-      "type": "screen"
-    },
-    {
-      "id": "f3x8qy",
-      "name": "New Screen",
-      "actorId": "owner",
-      "x": -471.5,
-      "y": 35.5,
-      "prompt": "",
-      "objects": [
-        {
-          "id": "3k96p9",
-          "entityId": "workspace",
-          "variant": "single",
-          "crud": [
-            "R"
-          ]
-        }
-      ],
-      "type": "screen"
-    },
-    {
-      "id": "1mjjl5",
-      "name": "New Screen2",
-      "actorId": "member-actor",
-      "x": -272.75,
-      "y": 74.5,
-      "prompt": "",
-      "objects": [],
-      "type": "screen"
+      "y": 280
     }
   ],
   "transitions": [
     {
-      "id": "n1",
-      "from": "project-list",
-      "to": "project-detail",
-      "trigger": "Tap row"
-    },
-    {
-      "id": "n2",
-      "from": "project-detail",
-      "to": "task-detail",
-      "trigger": "Tap task"
-    },
-    {
-      "id": "n3",
-      "from": "member-task-list",
-      "to": "member-task-detail",
-      "trigger": "Tap row"
-    },
-    {
-      "id": "oscbrq",
-      "from": "f3x8qy",
-      "to": "project-list",
-      "trigger": "Tap"
-    },
-    {
-      "id": "pe6uqx",
-      "from": "project-list",
-      "to": "owner-dashboard",
-      "trigger": "Tap"
-    },
-    {
-      "id": "4kysn5",
+      "id": "t1",
       "from": "owner-dashboard",
       "to": "project-list",
-      "trigger": "Tap"
+      "trigger": "Tap プロジェクト一覧"
+    },
+    {
+      "id": "t2",
+      "from": "project-list",
+      "to": "project-detail",
+      "trigger": "Tap プロジェクト行"
+    },
+    {
+      "id": "t3",
+      "from": "project-detail",
+      "to": "task-detail",
+      "trigger": "Tap タスクカード"
+    },
+    {
+      "id": "t4",
+      "from": "owner-dashboard",
+      "to": "member-management",
+      "trigger": "Tap メンバー管理"
+    },
+    {
+      "id": "t5",
+      "from": "project-list",
+      "to": "owner-dashboard",
+      "trigger": "Tap ダッシュボード"
+    },
+    {
+      "id": "t6",
+      "from": "project-detail",
+      "to": "label-management",
+      "trigger": "Tap ラベル設定"
+    },
+    {
+      "id": "t7",
+      "from": "member-my-tasks",
+      "to": "member-task-detail",
+      "trigger": "Tap タスク行"
+    },
+    {
+      "id": "t8",
+      "from": "member-my-tasks",
+      "to": "member-project-board",
+      "trigger": "Tap プロジェクト名"
+    },
+    {
+      "id": "t9",
+      "from": "member-project-board",
+      "to": "member-task-detail",
+      "trigger": "Tap タスクカード"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- テスト用ゴミデータ（不正scope、無名エンティティ、New Screen等）を削除
- entities/actorsを`product-model.json`テンプレートと整合
- PMツールらしい画面構成（ダッシュボード・メンバー管理・ラベル管理・プロジェクトボード）を追加
- transitionsのtriggerを日本語で意味のある名前に統一

## Test plan
- [ ] model-editor.htmlでsample JSONを読み込み、entities/actorsが正しく表示されること
- [ ] screen-editor.htmlでscreens/transitionsが正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)