### PR TITLE
refactor: ファイルI/OとReact UIを共通モジュールに抽出

### DIFF
--- a/docs/reqs/lib/file-io.js
+++ b/docs/reqs/lib/file-io.js
@@ -45,22 +45,27 @@
       saveTimer = setTimeout(function() { writeFile(); }, 500);
     }
 
+    // 成功時 true、失敗・スキップ時 false を返す
     async function writeFile() {
-      if (!fileHandle || isSaving) return;
+      if (!fileHandle || isSaving) return false;
       var full = config.getFullJson();
-      if (!full) return;
+      if (!full) return false;
       isSaving = true;
       updateStatus('saving', fileHandle.name, '');
+      var writable = null;
       try {
-        var w = await fileHandle.createWritable();
-        await w.write(JSON.stringify(full, null, 2) + '\n');
-        await w.close();
+        writable = await fileHandle.createWritable();
+        await writable.write(JSON.stringify(full, null, 2) + '\n');
+        await writable.close();
         updateStatus('connected', fileHandle.name);
         el(ids.edited).style.display = 'none';
+        return true;
       } catch (e) {
         console.error(e);
+        if (writable) try { await writable.abort(); } catch(_) {}
         updateStatus('error', 'Save failed');
         if (e.name === 'NotAllowedError') disconnectFile();
+        return false;
       } finally {
         isSaving = false;
       }
@@ -86,8 +91,22 @@
       updateStatus('connected', h.name);
     }
 
+    function loadJson(text, fileName) {
+      var d;
+      try { d = JSON.parse(text); } catch (parseErr) {
+        console.error('JSON parse error:', parseErr.message, fileName);
+        updateStatus('error', 'Invalid JSON');
+        return null;
+      }
+      return d;
+    }
+
     async function handleConnect() {
-      if (fileHandle) { await writeFile(); showToast('保存しました'); return; }
+      if (fileHandle) {
+        var ok = await writeFile();
+        if (ok) showToast('保存しました');
+        return;
+      }
       if (!('showOpenFilePicker' in window)) { showToast('JSONファイルをドロップしてください'); return; }
       try {
         var picked = await window.showOpenFilePicker({
@@ -97,13 +116,19 @@
         var h = picked[0];
         var f = await h.getFile();
         var t = await f.text();
-        var d;
-        try { d = JSON.parse(t); } catch (_) { updateStatus('error', 'Invalid JSON'); return; }
+        var d = loadJson(t, h.name);
+        if (!d) return;
         onFileConnected(h);
         var cb = window[config.loadDataKey];
         if (cb) cb(d);
       } catch (e) {
-        if (e.name !== 'AbortError') { console.error(e); updateStatus('error', 'Error'); }
+        if (e.name !== 'AbortError') {
+          console.error(e);
+          var msg = e.name === 'NotAllowedError' ? 'ファイルアクセスが拒否されました'
+                  : e.name === 'SecurityError' ? 'セキュリティエラー'
+                  : 'ファイルを開けませんでした';
+          updateStatus('error', msg);
+        }
       }
     }
 
@@ -133,21 +158,26 @@
         dragC = 0; ov.classList.remove('active');
         if (!e.dataTransfer.types.includes('Files')) return;
         e.preventDefault();
-        for (var item of [...e.dataTransfer.items]) {
-          if (item.kind !== 'file' || typeof item.getAsFileSystemHandle !== 'function') continue;
-          var h = await item.getAsFileSystemHandle();
-          if (h.kind === 'file' && h.name.endsWith('.json')) {
-            var f = await h.getFile();
-            var t = await f.text();
-            var d;
-            try { d = JSON.parse(t); } catch (_) { updateStatus('error', 'Invalid JSON'); return; }
-            onFileConnected(h);
-            var cb = window[config.loadDataKey];
-            if (cb) cb(d);
-            return;
+        try {
+          for (var item of [...e.dataTransfer.items]) {
+            if (item.kind !== 'file' || typeof item.getAsFileSystemHandle !== 'function') continue;
+            var h = await item.getAsFileSystemHandle();
+            if (h.kind === 'file' && h.name.endsWith('.json')) {
+              var f = await h.getFile();
+              var t = await f.text();
+              var d = loadJson(t, h.name);
+              if (!d) return;
+              onFileConnected(h);
+              var cb = window[config.loadDataKey];
+              if (cb) cb(d);
+              return;
+            }
           }
+          updateStatus('error', 'Drop not supported');
+        } catch (dropErr) {
+          console.error(dropErr);
+          updateStatus('error', 'ファイル読み込みに失敗しました');
         }
-        updateStatus('error', 'Drop not supported');
       });
     }
 
@@ -156,7 +186,11 @@
       document.addEventListener('keydown', function(e) {
         var mod = e.metaKey || e.ctrlKey;
         var inField = e.target.closest('input,textarea,select,[contenteditable]');
-        if (mod && e.key === 's') { e.preventDefault(); if (fileHandle) writeFile().then(function() { showToast('保存しました'); }); return; }
+        if (mod && e.key === 's') {
+          e.preventDefault();
+          if (fileHandle) writeFile().then(function(ok) { if (ok) showToast('保存しました'); });
+          return;
+        }
         if (inField) return;
         if (mod && e.key === 'z' && !e.shiftKey) { e.preventDefault(); window[keys.undo]?.(); }
         if (mod && (e.key === 'y' || (e.key === 'z' && e.shiftKey))) { e.preventDefault(); window[keys.redo]?.(); }

--- a/docs/reqs/lib/file-io.test.js
+++ b/docs/reqs/lib/file-io.test.js
@@ -3,15 +3,23 @@ import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
 const { createFileIO } = require('./file-io.js');
 
+const TEST_IDS = { toast:'t', dot:'d', label:'l', hint:'h', edited:'e', autoBtn:'a', overlay:'o' };
+const TEST_KEYS = { undo:'__u', redo:'__r', copy:'__c', paste:'__p', cut:'__x', del:'__d' };
+
+function makeConfig(overrides) {
+  return {
+    ids: TEST_IDS,
+    getFullJson: () => null,
+    loadDataKey: '__test',
+    keys: TEST_KEYS,
+    filePickerId: 'test',
+    ...overrides,
+  };
+}
+
 describe('createFileIO', () => {
   it('必要なメソッドを全て返す', () => {
-    const io = createFileIO({
-      ids: { toast: 't', dot: 'd', label: 'l', hint: 'h', edited: 'e', autoBtn: 'a', overlay: 'o' },
-      getFullJson: () => null,
-      loadDataKey: '__test',
-      keys: { undo: '__u', redo: '__r', copy: '__c', paste: '__p', cut: '__x', del: '__d' },
-      filePickerId: 'test',
-    });
+    const io = createFileIO(makeConfig());
     expect(typeof io.showToast).toBe('function');
     expect(typeof io.markModified).toBe('function');
     expect(typeof io.writeFile).toBe('function');
@@ -24,13 +32,21 @@ describe('createFileIO', () => {
   });
 
   it('初期状態ではfileHandleがnull', () => {
-    const io = createFileIO({
-      ids: { toast: 't', dot: 'd', label: 'l', hint: 'h', edited: 'e', autoBtn: 'a', overlay: 'o' },
-      getFullJson: () => null,
-      loadDataKey: '__test',
-      keys: { undo: '__u', redo: '__r', copy: '__c', paste: '__p', cut: '__x', del: '__d' },
-      filePickerId: 'test',
-    });
+    const io = createFileIO(makeConfig());
     expect(io.getFileHandle()).toBe(null);
+  });
+});
+
+describe('writeFile ガードロジック', () => {
+  it('fileHandleがnullの場合はfalseを返す', async () => {
+    const io = createFileIO(makeConfig());
+    const result = await io.writeFile();
+    expect(result).toBe(false);
+  });
+
+  it('getFullJsonがnullを返す場合はfalseを返す', async () => {
+    const io = createFileIO(makeConfig({ getFullJson: () => null }));
+    const result = await io.writeFile();
+    expect(result).toBe(false);
   });
 });

--- a/docs/reqs/lib/ui-components.js
+++ b/docs/reqs/lib/ui-components.js
@@ -21,10 +21,11 @@
   function Input(props) {
     var style = props.style, rest = Object.assign({}, props);
     delete rest.style;
+    var origFocus = rest.onFocus, origBlur = rest.onBlur;
     return h("input", Object.assign({}, rest, {
       style: Object.assign({border:"1px solid "+M3.outlineVar,borderRadius:M3.shapeSm,background:M3.surface,color:M3.onSurface,fontSize:14,fontWeight:400,lineHeight:"20px",padding:"8px 16px",outline:"none",width:"100%",boxSizing:"border-box",fontFamily:"inherit"}, style),
-      onFocus: function(e){e.target.style.borderColor="#1A73E8";e.target.style.boxShadow="0 0 0 3px rgba(26,115,232,.12)";},
-      onBlur: function(e){e.target.style.borderColor="";e.target.style.boxShadow="none";}
+      onFocus: function(e){e.target.style.borderColor="#1A73E8";e.target.style.boxShadow="0 0 0 3px rgba(26,115,232,.12)";if(origFocus)origFocus(e);},
+      onBlur: function(e){e.target.style.borderColor="";e.target.style.boxShadow="none";if(origBlur)origBlur(e);}
     }));
   }
 

--- a/docs/reqs/model-editor.html
+++ b/docs/reqs/model-editor.html
@@ -65,7 +65,7 @@ io.setupKeyboard();
 
 <script type="text/babel">
 const{useState,useRef,useCallback,useEffect}=React;
-const{M3,Input,Sel,Btn,SLabel,useInitialPan,useHistory}=window.__editorUI;
+const{M3,Input,Sel,Btn,SLabel,useInitialPan}=window.__editorUI;
 const{CRUD_OPS,CRUD_COLOR,CRUD_BG,ENT_PALETTE,ZOOM_MIN,ZOOM_MAX,MAX_HISTORY,uid,uniqueName,edgePt,calcCenterPan,labelWidth}=window.__editorLib;
 const{ensurePositions:_ensurePositions,CIRCLED,circled}=window.__editorLib;
 const entPalette=(ents,id)=>window.__editorLib.entPalette(ents,id);

--- a/docs/reqs/screen-editor.html
+++ b/docs/reqs/screen-editor.html
@@ -62,7 +62,7 @@ io.setupKeyboard();
 
 <script type="text/babel">
 const{useState,useRef,useCallback,useEffect}=React;
-const{M3,Input,Sel,Btn,SLabel,useInitialPan,useHistory}=window.__editorUI;
+const{M3,Input,Sel,Btn,SLabel,useInitialPan}=window.__editorUI;
 const{CRUD_OPS,CRUD_COLOR,CRUD_BG,ENT_PALETTE,ZOOM_MIN,ZOOM_MAX,MAX_HISTORY,uid,uniqueName,edgePt,calcCenterPan,labelWidth}=window.__editorLib;
 const _ensureScreenPositions=window.__editorLib.ensureScreenPositions;
 const entPalette=id=>window.__editorLib.entPalette(CONCEPT.entities,id);


### PR DESCRIPTION
## Summary

PR #83 の再作成（ベースブランチ誤りの修正）

- `lib/file-io.js`: ファイル接続・保存・自動保存・D&D・キーボードショートカットを `createFileIO` ファクトリに集約
- `lib/ui-components.js`: M3トークン, Input/Sel/Btn/SLabel, useInitialPan, useHistory を共通化（`React.createElement` ベース、file:// CORS回避）
- 両HTMLから重複コード約150行を削除

## Test plan

- [ ] `npx vitest run docs/reqs/lib/` — 全50テスト通過
- [ ] model-editor.htmlをブラウザで開き動作確認（ファイル接続・保存・Undo/Redo・ズーム/パン）
- [ ] screen-editor.htmlをブラウザで開き動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)