### PR TITLE
refactor: 両EditorにuseHistoryフックを適用

### DIFF
--- a/docs/reqs/model-editor.html
+++ b/docs/reqs/model-editor.html
@@ -65,7 +65,7 @@ io.setupKeyboard();
 
 <script type="text/babel">
 const{useState,useRef,useCallback,useEffect}=React;
-const{M3,Input,Sel,Btn,SLabel,useInitialPan}=window.__editorUI;
+const{M3,Input,Sel,Btn,SLabel,useInitialPan,useHistory}=window.__editorUI;
 const{CRUD_OPS,CRUD_COLOR,CRUD_BG,ENT_PALETTE,ZOOM_MIN,ZOOM_MAX,MAX_HISTORY,uid,uniqueName,edgePt,calcCenterPan,labelWidth}=window.__editorLib;
 const{ensurePositions:_ensurePositions,CIRCLED,circled}=window.__editorLib;
 const entPalette=(ents,id)=>window.__editorLib.entPalette(ents,id);
@@ -285,45 +285,11 @@ function ActorView({model,setModel,setModelSilent}){
 const TABS=[{id:"entity",label:"Entity"},{id:"actor",label:"Actor"}];
 
 function App(){
-  const[model,setModelRaw]=useState(EMPTY),[tab,setTab]=useState("entity");
+  const{data:model,setData:setModel,setDataSilent:setModelSilent,undo,redo,reset:resetHistory,histRef,dirtyRef}=useHistory(EMPTY,showToast);
+  const[tab,setTab]=useState("entity");
   const[entSelId,setEntSelId]=useState(null);
   const[selRelId,setSelRelId]=useState(null);
-  const histRef=useRef({stack:[EMPTY],idx:0});
   const clipRef=useRef(null);
-
-  // setModel: 履歴に積む（通常操作用）
-  const setModel=useCallback(updater=>{
-    setModelRaw(prev=>{
-      const next=typeof updater==='function'?updater(prev):updater;
-      const h=histRef.current;
-      h.stack=h.stack.slice(0,h.idx+1);
-      h.stack.push(JSON.parse(JSON.stringify(next)));
-      if(h.stack.length>MAX_HISTORY){h.stack.shift();}else{h.idx++;}
-      return next;
-    });
-  },[]);
-  // setModelSilent: 履歴に積まない（ドラッグ中の移動用）
-  const setModelSilent=useCallback(updater=>{
-    setModelRaw(prev=>typeof updater==='function'?updater(prev):updater);
-  },[]);
-
-  // Undo
-  const undo=useCallback(()=>{
-    const h=histRef.current;
-    if(h.idx<=0)return;
-    h.idx--;
-    setModelRaw(JSON.parse(JSON.stringify(h.stack[h.idx])));
-    showToast('Undo');
-  },[]);
-
-  // Redo
-  const redo=useCallback(()=>{
-    const h=histRef.current;
-    if(h.idx>=h.stack.length-1)return;
-    h.idx++;
-    setModelRaw(JSON.parse(JSON.stringify(h.stack[h.idx])));
-    showToast('Redo');
-  },[]);
 
   // Copy: エンティティ選択時のみ動作
   const handleCopy=useCallback(()=>{
@@ -391,15 +357,13 @@ function App(){
     return()=>{window.__cmUndo=window.__cmRedo=window.__cmCopy=window.__cmPaste=window.__cmCut=window.__cmDelete=null;};
   },[undo,redo,handleCopy,handlePaste,handleCut,handleDelete]);
 
-  const initialLoad=useRef(true);
-  useEffect(()=>{modelRef=model;if(initialLoad.current){initialLoad.current=false;}else{markModified();}},[model]);
+  useEffect(()=>{modelRef=model;if(dirtyRef.current){dirtyRef.current=false;markModified();}},[model]);
   useEffect(()=>{
     window.__cmLoadData=d=>{
       const cmData=splitData(d);
       const loaded=ensurePositions(cmData);
       loadGenRef.current++;
-      setModelRaw(loaded);
-      histRef.current={stack:[JSON.parse(JSON.stringify(loaded))],idx:0};
+      resetHistory(loaded);
       setTab("entity");
       setEntSelId(null);
       setSelRelId(null);

--- a/docs/reqs/screen-editor.html
+++ b/docs/reqs/screen-editor.html
@@ -62,7 +62,7 @@ io.setupKeyboard();
 
 <script type="text/babel">
 const{useState,useRef,useCallback,useEffect}=React;
-const{M3,Input,Sel,Btn,SLabel,useInitialPan}=window.__editorUI;
+const{M3,Input,Sel,Btn,SLabel,useInitialPan,useHistory}=window.__editorUI;
 const{CRUD_OPS,CRUD_COLOR,CRUD_BG,ENT_PALETTE,ZOOM_MIN,ZOOM_MAX,MAX_HISTORY,uid,uniqueName,edgePt,calcCenterPan,labelWidth}=window.__editorLib;
 const _ensureScreenPositions=window.__editorLib.ensureScreenPositions;
 const entPalette=id=>window.__editorLib.entPalette(CONCEPT.entities,id);
@@ -280,27 +280,8 @@ function SingleWF({obj,crud,color}){const ops=crud||[];const actions=[];if(ops.i
 const TABS=[{id:"map",label:"Map"},{id:"detail",label:"Screen"}];
 
 function App(){
-  const[screens,setScreensRaw]=useState(EMPTY),[view,setView]=useState("map"),[scrId,setScrId]=useState(null),[detailActorId,setDetailActorId]=useState(null);
-  const histRef=useRef({stack:[EMPTY],idx:0});
-  const dirtyRef=useRef(false);
-
-  const setScreens=useCallback(updater=>{
-    dirtyRef.current=true;
-    setScreensRaw(prev=>{
-      const next=typeof updater==='function'?updater(prev):updater;
-      const h=histRef.current;
-      h.stack=h.stack.slice(0,h.idx+1);
-      h.stack.push(JSON.parse(JSON.stringify(next)));
-      if(h.stack.length>MAX_HISTORY){h.stack.shift();}else{h.idx++;}
-      return next;
-    });
-  },[]);
-  const setScreensSilent=useCallback(updater=>{
-    setScreensRaw(prev=>typeof updater==='function'?updater(prev):updater);
-  },[]);
-
-  const undo=useCallback(()=>{const h=histRef.current;if(h.idx<=0)return;h.idx--;dirtyRef.current=true;setScreensRaw(JSON.parse(JSON.stringify(h.stack[h.idx])));showToast('Undo');},[]);
-  const redo=useCallback(()=>{const h=histRef.current;if(h.idx>=h.stack.length-1)return;h.idx++;dirtyRef.current=true;setScreensRaw(JSON.parse(JSON.stringify(h.stack[h.idx])));showToast('Redo');},[]);
+  const{data:screens,setData:setScreens,setDataSilent:setScreensSilent,undo,redo,reset:resetHistory,histRef,dirtyRef}=useHistory(EMPTY,showToast);
+  const[view,setView]=useState("map"),[scrId,setScrId]=useState(null),[detailActorId,setDetailActorId]=useState(null);
   // Map View からの選択状態参照用
   const selRef=useRef({scrId:null,navId:null});
   const clipRef=useRef(null);
@@ -367,8 +348,7 @@ function App(){
     window.__scLoadData=d=>{
       const scData=_ensureScreenPositions(splitData(d),CONCEPT.actors,{cols:SC_GRID_COLS,gapX:SC_GRID_GAP_X,gapY:SC_GRID_GAP_Y,padX:SC_GRID_PAD_X,padY:SC_GRID_PAD_Y,minSpanFactor:SC_MIN_SPAN_FACTOR,minSpanMin:SC_MIN_SPAN_MIN});
       loadGenRef.current++;
-      setScreensRaw(scData);
-      histRef.current={stack:[JSON.parse(JSON.stringify(scData))],idx:0};
+      resetHistory(scData);
       setView("map");setScrId(null);
     };
     return()=>{window.__scLoadData=null;};


### PR DESCRIPTION
## Summary

- 両HTMLのApp関数内にあった履歴管理コード（setData/setDataSilent/undo/redo/histRef/dirtyRef）を `ui-components.js` の `useHistory` フックに置換
- `resetHistory` でデータロード時の履歴リセットを簡潔に
- model-editorの `initialLoad` ref を `dirtyRef` に統一（useHistoryが提供）
- 両HTMLから合計約54行削減

## Test plan

- [ ] model-editor: Undo/Redo（Ctrl+Z/Y）が正常に動作すること
- [ ] model-editor: ファイル接続後にエンティティ追加→Undo→Redo が正しく動くこと
- [ ] screen-editor: Undo/Redo が正常に動作すること
- [ ] screen-editor: ファイル接続後にスクリーン追加→Undo→Redo が正しく動くこと
- [ ] 両エディタ: ドラッグ中の位置変更が履歴に1回だけ記録されること（Silent更新）

🤖 Generated with [Claude Code](https://claude.com/claude-code)